### PR TITLE
docs: add a comment for the cw721 example's callable points

### DIFF
--- a/contracts/auction/contracts/cw721-base-dynamiclink/src/lib.rs
+++ b/contracts/auction/contracts/cw721-base-dynamiclink/src/lib.rs
@@ -53,6 +53,11 @@ pub mod entry {
     }
 }
 
+// These callable points do not cover all cw721 message/query.
+// Although these should cover all of them, they implements only
+// callable points used by auction contract.
+// After we define the starndard interfaces for cw721 for dynamic link,
+// we should remake them according to them.
 #[callable_points]
 mod callable_points {
     use super::*;


### PR DESCRIPTION
This PR adds a comment for the cw721 example's callable points.
This comment is for telling these callable points do not cover all of cw721 query and messages.